### PR TITLE
Added nodeSelector value to helm chart

### DIFF
--- a/charts/adcs-issuer/Chart.yaml
+++ b/charts/adcs-issuer/Chart.yaml
@@ -13,10 +13,10 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 2.1.0
+version: 2.1.1
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "2.1.0"
+appVersion: "2.1.1"
 

--- a/charts/adcs-issuer/templates/deployment.yaml
+++ b/charts/adcs-issuer/templates/deployment.yaml
@@ -112,3 +112,8 @@ spec:
           defaultMode: 420
           secretName: {{ .Values.controllerManager.caCertsSecretName| default "ca-certificates" }} 
       {{- end }}  
+
+      {{- with .Values.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}

--- a/charts/adcs-issuer/templates/simulator-deployment.yaml
+++ b/charts/adcs-issuer/templates/simulator-deployment.yaml
@@ -104,5 +104,9 @@ spec:
           secret:
             secretName: {{.Values.simulator.secretCertificateName | default "adcs-sim-certificate-secret" }} # secret for storing ca key
 
+      {{- with .Values.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
 
 {{- end  }}    

--- a/charts/adcs-issuer/values.yaml
+++ b/charts/adcs-issuer/values.yaml
@@ -74,7 +74,7 @@ webhookService:
     targetPort: 9443
   type: ClusterIP
 
-
+nodeSelector: {}
 
 # ADCS Simulator 
 


### PR DESCRIPTION
Adds a `nodeSelector` value to the chart for mixed clusters with `linux` and `windows` nodes

Adresses #87