### PR TITLE
fix(helm): ensure metrics port exists on pod spec

### DIFF
--- a/charts/adcs-issuer/Chart.yaml
+++ b/charts/adcs-issuer/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: adcs-issuer
 description: ADCS Issuer plugin for cert-manager.
 type: application
-version: 3.0.1
-appVersion: "2.1.2"
+version: 3.0.2
+appVersion: "2.1.4"
 home: https://github.com/djkormo/adcs-issuer
 sources:
   - https://github.com/djkormo/adcs-issuer

--- a/charts/adcs-issuer/templates/deployment.yaml
+++ b/charts/adcs-issuer/templates/deployment.yaml
@@ -75,6 +75,9 @@ spec:
                 fieldRef:
                   fieldPath: metadata.namespace
           ports:
+            - containerPort: 8080
+              name: metrics
+              protocol: TCP
             - containerPort: 9443
               name: webhook-server
               protocol: TCP

--- a/charts/adcs-issuer/values.yaml
+++ b/charts/adcs-issuer/values.yaml
@@ -125,7 +125,7 @@ metricsService:
   ports:
   - name: http
     port: 8080
-    targetPort: 8080
+    targetPort: metrics
   type: ClusterIP                             # Type of Kubernetes service.
 
 # @section Webhook Service


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- To help with semantic versioning the PR title should start with one of the conventional commit types. -->
<!--- The conventional commit types for Semantic PR are: feat, fix, docs, style, refactor, perf, test, build, ci, chore, revert -->

#### Description
<!--- Describe your changes in detail -->
Ensure the port that the metrics service points at is defined in the pod specification.

Also bumping the helm chart appVersion to use the latest release.

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Currently, the metrics service points at a port that is not defined in the pod spec.

This means there is no endpoint for the service and consequently the `ServiceMonitor` is unable to scrape metrics.

This PR adds the metrics port to the pod specification.

#### Screenshots (if appropriate):

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
Tested locally (& has CI coverage)

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

For new Helm chart releases:
- [x] I have bumped the Helm chart version.
