### PR TITLE
fix(helm): do not hardcode entrypoint path

### DIFF
--- a/charts/adcs-issuer/Chart.yaml
+++ b/charts/adcs-issuer/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: adcs-issuer
 description: ADCS Issuer plugin for cert-manager.
 type: application
-version: 3.0.2
+version: 3.0.3-rc1
 appVersion: "2.1.4"
 home: https://github.com/djkormo/adcs-issuer
 sources:

--- a/charts/adcs-issuer/templates/deployment.yaml
+++ b/charts/adcs-issuer/templates/deployment.yaml
@@ -55,8 +55,6 @@ spec:
         - name: manager
           image: {{ .Values.controllerManager.manager.image.repository }}:{{ .Values.controllerManager.manager.image.tag | default .Chart.AppVersion }}
           imagePullPolicy: Always
-          command:
-            - /manager
           {{- if .Values.controllerManager.arguments }}
           args:
             {{- range $key, $value := .Values.controllerManager.arguments }}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- To help with semantic versioning the PR title should start with one of the conventional commit types. -->
<!--- The conventional commit types for Semantic PR are: feat, fix, docs, style, refactor, perf, test, build, ci, chore, revert -->

#### Description
<!--- Describe your changes in detail -->

Previously the container command was hardcoded as `/manager` in the Helm chart. This does not work for images built with `ko`. We shouldn't need to override this so let's remove the configuration option entirely

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
We recently updated the CI to use goreleaser and ko, but the images that are created by this do not work with the Helm chart.

#### Screenshots (if appropriate):

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have updated the documentation accordingly.
- [ ] I have updated the tests accordingly.
- [ ] I have run `make generate` and checked in the results.
- [ ] I have run `make manifests` and checked in the results.

For new code releases:
- [ ] I have bumped the `appVersion` in the Helm chart.

For new Helm chart releases:
- [x] I have bumped the Helm chart version.
