### PR TITLE
(chore) add configurable imagePullPolicy for controller manager and simulator

### DIFF
--- a/charts/adcs-issuer/Chart.yaml
+++ b/charts/adcs-issuer/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: adcs-issuer
 description: ADCS Issuer plugin for cert-manager.
 type: application
-version: 2.1.5
+version: 2.1.6
 appVersion: "2.1.5"
 home: https://github.com/djkormo/adcs-issuer
 sources:

--- a/charts/adcs-issuer/README.md
+++ b/charts/adcs-issuer/README.md
@@ -40,7 +40,8 @@ Kubernetes: `>=1.16.0-0`
 | controllerManager.environment.ENABLE_WEBHOOKS | string | `"false"` |  |
 | controllerManager.environment.KUBERNETES_CLUSTER_DOMAIN | string | `"cluster.local"` |  |
 | controllerManager.manager.image.repository | string | `"djkormo/adcs-issuer"` |  |
-| controllerManager.manager.image.tag | string | `"2.1.2"` |  |
+| controllerManager.manager.image.tag | string | `"2.1.5"` |  |
+| controllerManager.manager.image.imagePullPolicy | string | `"Always"` |  |
 | controllerManager.manager.livenessProbe.httpGet.path | string | `"/healthz"` |  |
 | controllerManager.manager.livenessProbe.httpGet.port | int | `8081` |  |
 | controllerManager.manager.livenessProbe.httpGet.scheme | string | `"HTTP"` |  |
@@ -94,6 +95,7 @@ Kubernetes: `>=1.16.0-0`
 | simulator.exampleCertificate.name | string | `"adcs-sim-certificate"` |  |
 | simulator.image.repository | string | `"djkormo/adcs-sim"` |  |
 | simulator.image.tag | string | `"0.0.6"` |  |
+| simulator.image.imagePullPolicy | string | `"Always"` |  |
 | simulator.issuerGroup | string | `"cert-manager.io"` |  |
 | simulator.issuerKind | string | `"Issuer"` |  |
 | simulator.issuerName | string | `"adcs-sim-issuer"` |  |

--- a/charts/adcs-issuer/templates/deployment.yaml
+++ b/charts/adcs-issuer/templates/deployment.yaml
@@ -54,7 +54,7 @@ spec:
       containers:
         - name: manager
           image: {{ .Values.controllerManager.manager.image.repository }}:{{ .Values.controllerManager.manager.image.tag | default .Chart.AppVersion }}
-          imagePullPolicy: Always
+          imagePullPolicy: {{ .Values.controllerManager.manager.image.imagePullPolicy | default "Always" }}
           {{- if .Values.controllerManager.arguments }}
           args:
             {{- range $key, $value := .Values.controllerManager.arguments }}

--- a/charts/adcs-issuer/templates/simulator-deployment.yaml
+++ b/charts/adcs-issuer/templates/simulator-deployment.yaml
@@ -29,7 +29,7 @@ spec:
       containers:
         - name: manager
           image: {{ .Values.simulator.image.repository }}:{{ .Values.simulator.image.tag }}
-          imagePullPolicy: Always
+          imagePullPolicy: {{ .Values.simulator.image.imagePullPolicy | default "Always" }}
           command:
             - /usr/local/adcs-sim/manager
           {{- if .Values.simulator.arguments }}

--- a/charts/adcs-issuer/values.yaml
+++ b/charts/adcs-issuer/values.yaml
@@ -12,6 +12,7 @@ controllerManager:
     image:
       repository: djkormo/adcs-issuer  # The repository for the ADCS Issuer Docker image.
       tag: 2.1.5                       # The tag for the ADCS Issuer Docker image.
+      imagePullPolicy: Always          # The image pull policy.
     
     # @section Resources
     # Resource requests and limits for the ADCS Issuer container.
@@ -165,6 +166,7 @@ simulator:
   image:
     repository: djkormo/adcs-sim              # The repository for the ADCS Simulator Docker image.
     tag: 0.0.6                                # The tag for the ADCS Simulator Docker image.
+    imagePullPolicy: Always                   # The image pull policy for the ADCS Simulator Docker image.
 
   # @section Environment Variables
   # Environment variables for the simulator.


### PR DESCRIPTION
#### Description
Added imagePullPolicy as a configurable value instead and added references in deployment templates

#### Motivation and Context
To run the adcs-issuer in an airgapped environment the imagepullpolicy needs to be changed to never or ifnotpresent (assuming the image is still available), this enables the user to change the setting without patching templates

Could also be useful for slower and/or unstable connections.

#### How Has This Been Tested?
Unsure if any tests needs to be updated.

#### Checklist:
- [x] I have updated the documentation accordingly.
- [ ] I have updated the tests accordingly.
- [x] I have run `make generate` and checked in the results.
- [x] I have run `make manifests` and checked in the results.

For new code releases:
- [ ] I have bumped the `appVersion` in the Helm chart.

For new Helm chart releases:
- [x] I have bumped the Helm chart version.
